### PR TITLE
Display `NSAlert()` when `loadGame()` fails

### DIFF
--- a/speccyMac/Spectrum.swift
+++ b/speccyMac/Spectrum.swift
@@ -351,7 +351,9 @@ class Spectrum: Machine {
             processor.counter = 0
             processor.unpause()
         } else {
-            print("couldnt load \(game)")
+            let alert = NSAlert()
+            alert.messageText = "Couldn't load:\n\n\(game)"
+            alert.runModal()
         }
     }
 }


### PR DESCRIPTION
`NSAlert()` code based on the code in Machine.swift for an unemulated instruction